### PR TITLE
Feature/fix auto focus text input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,7 @@ docker/*local*
 test-report.html
 superset/static/stats/statistics.html
 .aider*
+
+.history
+/memory
+/.github/prompts

--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -27,6 +27,10 @@ if [ "$BUILD_SUPERSET_FRONTEND_IN_DOCKER" = "true" ]; then
     echo "Building Superset frontend in dev mode inside docker container"
     cd /app/superset-frontend
 
+    echo "Installing zstd as prerequisite" 
+    apt update 
+    apt install -y zstd
+
     if [ "$NPM_RUN_PRUNE" = "true" ]; then
         echo "Running `npm run prune`"
         npm run prune

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -443,6 +443,16 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
   const [isSearchFocused, setIsSearchFocused] = useState(true);
   const isActivelySearching = isSearchFocused && !!searchInputValue;
 
+  // Auto-focus search input when modal opens
+  useEffect(() => {
+    // Small delay ensures modal is fully rendered and animated
+    const timer = setTimeout(() => {
+      searchInputRef.current?.focus();
+    }, 201);
+
+    return () => clearTimeout(timer);
+  }, []);
+
   const selectedVizMetadata: ChartMetadata | null = selectedViz
     ? mountedPluginMetadata[selectedViz]
     : null;


### PR DESCRIPTION
### SUMMARY
This pull request introduces improvements to the user experience in the visualization type gallery modal. The most notable changes include is enhancing the modal's usability by automatically focusing the search input.

### TESTING INSTRUCTIONS
1. Open any chart in Explore view
2. Click "Change Visualization Type" button
3. Modal opens
4. Verify cursor is automatically in the search input
5. Start typing immediately without clicking

### ADDITIONAL INFORMATION
- [ ] Fixes #5 
- [ ]  Added installation of `zstd` as a prerequisite in the Docker frontend build script to ensure required dependencies are available before building the Superset frontend.
