### PR TITLE
Feature/fix big query query generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,10 @@ docker/*local*
 test-report.html
 superset/static/stats/statistics.html
 .aider*
+/.claude
+/.github
+/.claude
+/.cursor
+/.history
+/memory
+CLAUDE.md

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1468,8 +1468,24 @@ class SqlaTable(
 
     def get_sqla_table(self) -> TableClause:
         tbl = table(self.table_name)
-        if self.schema:
+        
+        # For databases that support catalogs, combine catalog + schema using schema prefixing
+        # This is a workaround for SQLAlchemy 1.4's limitation where TableClause doesn't have
+        # a catalog attribute. BigQuery and similar databases support three-part identifiers
+        # (catalog.schema.table), so we combine them into the schema attribute.
+        if (hasattr(self.db_engine_spec, 'supports_catalog') and 
+            self.db_engine_spec.supports_catalog and 
+            self.catalog):
+            # BigQuery format: project.dataset.table
+            if self.schema:
+                tbl.schema = f"{self.catalog}.{self.schema}"
+            else:
+                # Catalog only (no schema) - use catalog as schema
+                tbl.schema = self.catalog
+        elif self.schema:
+            # No catalog support or no catalog set
             tbl.schema = self.schema
+
         return tbl
 
     def get_from_clause(


### PR DESCRIPTION
### SUMMARY
This pull request improves support for databases that use catalogs (such as BigQuery) by enhancing how the `get_sqla_table` method constructs table references. The main change is a workaround for SQLAlchemy's lack of native catalog support, enabling proper handling of three-part identifiers (catalog.schema.table).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE
<img width="2540" height="1285" alt="Screenshot 2025-10-19 at 17-11-59 DEV Superset" src="https://github.com/user-attachments/assets/9555282d-845c-4828-ba04-c5f1ade5391b" />
#### AFTER
<img width="2540" height="1285" alt="Screenshot 2025-10-20 at 00-16-37 DEV Superset" src="https://github.com/user-attachments/assets/1dd923fd-3495-48ea-8cd5-1ab296f6132b" />

### TESTING INSTRUCTIONS
1. Connect to a BigQuery database
2. Edit the database by clicking on the ✏️ icon and going through Advanced &rarr; Other &rarr; and clicking allow changing catalogs
3. Create a dataset with a specific project ID (Click on the Dataset Tab and Press the ➕ button in the top-right, and making sure you select BigQuery as your database source)
4. Navigate to the Explore view (Dataset tab and click on the newly created dataset)
5. Observe the generated SQL query

### DEMO VIDEO


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: #6 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
