### PR TITLE
fix(html): display strings with angle brackets in query results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,5 @@ docker/*local*
 test-report.html
 superset/static/stats/statistics.html
 .aider*
+
+.cursor/

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -321,7 +321,10 @@
     "eslint-rules/eslint-plugin-icons": {
       "version": "1.0.0",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
+      }
     },
     "eslint-rules/eslint-plugin-theme-colors": {
       "version": "1.0.0",

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
@@ -24,6 +24,7 @@ import {
   removeHTMLTags,
   isJsonString,
   getParagraphContents,
+  escapeHtml,
 } from './html';
 
 describe('sanitizeHtml', () => {
@@ -187,5 +188,51 @@ describe('getParagraphContents', () => {
     expect(result).toEqual({
       p1: 'First paragraph with nested content.',
     });
+  });
+});
+
+describe('escapeHtml', () => {
+  test('should escape angle brackets', () => {
+    const input = '<div>test</div>';
+    const output = escapeHtml(input);
+    expect(output).toBe('&lt;div&gt;test&lt;/div&gt;');
+  });
+
+  test('should escape ampersand', () => {
+    const input = 'A & B';
+    const output = escapeHtml(input);
+    expect(output).toBe('A &amp; B');
+  });
+
+  test('should escape quotes', () => {
+    const input = 'Say "hello" and \'hi\'';
+    const output = escapeHtml(input);
+    expect(output).toBe('Say &quot;hello&quot; and &#39;hi&#39;');
+  });
+
+  test('should escape all HTML entities in complex string', () => {
+    const input = '<script>alert("XSS & more")</script>';
+    const output = escapeHtml(input);
+    expect(output).toBe(
+      '&lt;script&gt;alert(&quot;XSS &amp; more&quot;)&lt;/script&gt;',
+    );
+  });
+
+  test('should return plain text unchanged', () => {
+    const input = 'Just plain text';
+    const output = escapeHtml(input);
+    expect(output).toBe('Just plain text');
+  });
+
+  test('should handle strings with comparison operators', () => {
+    const input = 'a <= 10 and b > 10';
+    const output = escapeHtml(input);
+    expect(output).toBe('a &lt;= 10 and b &gt; 10');
+  });
+
+  test('should handle empty string', () => {
+    const input = '';
+    const output = escapeHtml(input);
+    expect(output).toBe('');
   });
 });

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -87,6 +87,24 @@ export function removeHTMLTags(str: string): string {
   return str.replace(/<[^>]*>/g, '');
 }
 
+/**
+ * Escapes HTML entities in a string to prevent it from being interpreted as HTML.
+ * This is useful for displaying strings containing angle brackets as plain text.
+ *
+ * @param str - The string to escape
+ * @returns The escaped string with HTML entities
+ */
+export function escapeHtml(str: string): string {
+  const escapeMap: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  };
+  return str.replace(/[&<>"']/g, match => escapeMap[match]);
+}
+
 export function isJsonString(str: string): boolean {
   try {
     JSON.parse(str);

--- a/superset-frontend/src/components/FilterableTable/utils.tsx
+++ b/superset-frontend/src/components/FilterableTable/utils.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { JsonModal, safeJsonObjectParse } from 'src/components/JsonModal';
-import { t, safeHtmlSpan } from '@superset-ui/core';
+import { t, safeHtmlSpan, escapeHtml, isProbablyHTML } from '@superset-ui/core';
 import { NULL_STRING, CellDataType } from './useCellContentParser';
 
 type CellParams = {
@@ -51,7 +51,26 @@ export const renderResultCell = ({
       />
     );
   }
-  if (allowHTML && typeof cellData === 'string') {
+  if (typeof cellData === 'string') {
+    // For SQL Lab query results, always display strings as text (not as HTML)
+    // Escape HTML entities so strings like '<div>test</div>' display correctly
+    if (!allowHTML) {
+      // When HTML is not allowed, always escape entities
+      // Wrap in span and use dangerouslySetInnerHTML to ensure proper rendering
+      return (
+        <span dangerouslySetInnerHTML={{ __html: escapeHtml(cellNode) }} />
+      );
+    }
+    // When HTML is allowed, check if it looks like HTML
+    // If it does, escape it to display as text (SQL results should show actual values)
+    // If it doesn't, use safeHtmlSpan for potential HTML rendering
+    if (isProbablyHTML(cellNode)) {
+      // Escape HTML-like strings to display them as literal text
+      // Use dangerouslySetInnerHTML so the browser decodes the entities correctly
+      return (
+        <span dangerouslySetInnerHTML={{ __html: escapeHtml(cellNode) }} />
+      );
+    }
     return safeHtmlSpan(cellNode);
   }
   return cellNode;


### PR DESCRIPTION
fix(html): display strings with angle brackets in query results
- Implemented escapeHtml function to escape HTML entities in strings.
- Added unit tests for escapeHtml to ensure correct functionality.
- Updated FilterableTable to use escapeHtml for rendering string data safely.
- Modified .gitignore to include .cursor/ files.
- Updated package-lock.json to add peerDependencies for eslint-plugin-icons.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

fix(sqllab): display strings with angle brackets in query results

### SUMMARY

Fixes a bug where SQL Lab query results containing strings with angle brackets (like `<div>test</div>`) were not displaying correctly. The issue occurred because HTML sanitization logic was incorrectly treating these strings as HTML and attempting to render them, which resulted in empty or missing cells.

**Root Cause:**
When `renderResultCell` detected HTML-like strings via `isProbablyHTML()`, it passed them to `safeHtmlSpan()` which sanitized and attempted to render them as HTML using `dangerouslySetInnerHTML`. For SQL query results, these should be displayed as literal text values, not rendered as HTML.

**Solution:**
1. Added `escapeHtml()` utility function to properly escape HTML entities (`<`, `>`, `&`, `"`, `'`) for safe text display
2. Updated `renderResultCell()` to escape HTML-like strings when displaying SQL query results, ensuring they appear as literal text with visible angle brackets
3. Added comprehensive unit tests for the new `escapeHtml()` function

**Technical Changes:**
- **New function**: `escapeHtml()` in `superset-frontend/packages/superset-ui-core/src/utils/html.tsx`
  - Escapes HTML entities to prevent strings from being interpreted as HTML
  - Returns escaped string (e.g., `<div>test</div>` → `&lt;div&gt;test&lt;/div&gt;`)
  
- **Updated**: `renderResultCell()` in `superset-frontend/src/components/FilterableTable/utils.tsx`
  - When `allowHTML=false`: Always escapes HTML entities
  - When `allowHTML=true` and string looks like HTML: Escapes it to display as literal text (for SQL results)
  - Uses `dangerouslySetInnerHTML` with escaped content so browser correctly decodes entities for display

**Security:**
The fix maintains security by escaping HTML entities, preventing XSS attacks while displaying all data correctly. Strings are displayed as text, not rendered as HTML.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:**
- Strings with angle brackets appeared as empty cells or missing data
- Example: `SELECT '<div>test</div>' as html_string` showed empty cell
<img width="1835" height="966" alt="Screenshot 2025-11-02 141808" src="https://github.com/user-attachments/assets/65529727-81ac-47c5-b7c8-d2c3dcf65b4f" />

**After:**
- Strings with angle brackets display correctly with visible characters
- Example: `SELECT '<div>test</div>' as html_string` shows `<div>test</div>` with visible angle brackets
<img width="1835" height="966" alt="Screenshot 2025-11-02 142051" src="https://github.com/user-attachments/assets/db2e2b2a-ddfc-4a7e-8cde-a4ffceebcc8e" />

### TESTING INSTRUCTIONS

1. **Open SQL Lab** in Superset
2. **Execute a query** with strings containing angle brackets:
   ```sql
   SELECT '<div>test</div>' as html_string, 
          '<script>alert("xss")</script>' as script_string,
          'a < b and c > d' as comparison_string
   ```
3. **Verify the results grid** displays all values correctly:
   - `html_string` should show: `<div>test</div>` (with visible angle brackets)
   - `script_string` should show: `<script>alert("xss")</script>` (escaped and visible)
   - `comparison_string` should show: `a < b and c > d` (with visible angle brackets)
4. **Test with various HTML-like strings** to ensure they all display as text:
   - Tags: `<div>`, `<span>`, `<p>`, etc.
   - Comparison operators: `a <= 10 and b > 20`
   - XML/HTML snippets
5. **Verify security**: Confirm that actual HTML injection attempts are still properly escaped and don't execute

**Automated Tests:**
- Unit tests for `escapeHtml()` function (7 test cases covering various scenarios)
- Tests verify correct escaping of `<`, `>`, `&`, `"`, `'` characters
- Tests verify plain text strings remain unchanged

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #4
- [ ] Required feature flags: None
- [x] Changes UI: Fixes display of query results in SQL Lab
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No (bug fix)
- [ ] Removes existing feature or API: No