### PR TITLE
fix(explore): update browser tab title to show chart name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 *.bak
+.cursor/*
 *.db
 *.pyc
 *.sqllite

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -321,7 +321,10 @@
     "eslint-rules/eslint-plugin-icons": {
       "version": "1.0.0",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
+      }
     },
     "eslint-rules/eslint-plugin-theme-colors": {
       "version": "1.0.0",

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -71,6 +71,8 @@ import DataSourcePanel from '../DatasourcePanel';
 import ConnectedExploreChartHeader from '../ExploreChartHeader';
 import ExploreContainer from '../ExploreContainer';
 
+const originalDocumentTitle = document.title;
+
 const propTypes = {
   ...ExploreChartPanel.propTypes,
   actions: PropTypes.object.isRequired,
@@ -272,9 +274,9 @@ function ExploreViewContainer(props) {
     async ({ isReplace = false, title } = {}) => {
       const formData = props.dashboardId
         ? {
-            ...props.form_data,
-            dashboardId: props.dashboardId,
-          }
+          ...props.form_data,
+          dashboardId: props.dashboardId,
+        }
         : props.form_data;
       const { id: datasourceId, type: datasourceType } = props.datasource;
 
@@ -363,8 +365,8 @@ function ExploreViewContainer(props) {
       LOG_ACTIONS_MOUNT_EXPLORER,
       props.slice?.slice_id
         ? {
-            slice_id: props.slice.slice_id,
-          }
+          slice_id: props.slice.slice_id,
+        }
         : undefined,
     );
   });
@@ -414,13 +416,24 @@ function ExploreViewContainer(props) {
     }
   }, []);
 
+  useEffect(() => {
+    if (props.sliceName) {
+      document.title = props.sliceName;
+    } else {
+      document.title = originalDocumentTitle;
+    }
+    return () => {
+      document.title = originalDocumentTitle;
+    };
+  }, [props.sliceName]);
+
   const reRenderChart = useCallback(
     controlsChanged => {
       const newQueryFormData = controlsChanged
         ? {
-            ...props.chart.latestQueryFormData,
-            ...getFormDataFromControls(pick(props.controls, controlsChanged)),
-          }
+          ...props.chart.latestQueryFormData,
+          ...getFormDataFromControls(pick(props.controls, controlsChanged)),
+        }
         : getFormDataFromControls(props.controls);
       props.actions.updateQueryFormData(newQueryFormData, props.chart.id);
       props.actions.renderTriggered(new Date().getTime(), props.chart.id);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR fixes the browser tab title not updating when opening charts in Explore view. Previously, the tab title remained generic even when viewing a specific chart, making it difficult to identify which chart is open when multiple tabs are present.

**Changes:**
- Added `originalDocumentTitle` constant to capture the default title at module load
- Implemented `useEffect` hook in `ExploreViewContainer` to update `document.title` when `sliceName` prop changes
- Added cleanup function to reset title when component unmounts or when navigating away

**Design Decisions:**
- Follows the same pattern used in `DashboardPage.tsx` for consistency
- Updates title reactively based on `props.sliceName` from Redux state
- Handles edge cases: unsaved charts (null sliceName), chart name changes, and navigation cleanup
- No breaking changes - purely additive functionality

Fixes #7

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

**Before:** Browser tab shows generic "Superset" title even when viewing a specific chart.
![issue_before](https://github.com/user-attachments/assets/3619305a-df85-492c-9e07-3917ec80ae1d)

**After:** Browser tab displays the chart name (e.g., "Sales by Region") when viewing a chart in Explore view.
![issue_after](https://github.com/user-attachments/assets/ab10645f-b50f-4f01-b39f-3cb3a66c53a5)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. **Test chart title update:**
   - Navigate to Superset and open an existing chart in Explore view (`/explore/`)
   - Verify the browser tab title displays the chart's name
   - Open a different chart in a new tab
   - Verify the new tab shows the second chart's name

2. **Test title reset on navigation:**
   - While viewing a chart, navigate away (e.g., go to home page or dashboard list)
   - Verify the tab title resets to the default "Superset" title

3. **Test unsaved charts:**
   - Create a new chart (unsaved chart with no name)
   - Verify the tab title remains at the default title

4. **Test chart name changes:**
   - Open a chart and verify the title shows the chart name
   - Edit the chart name (if you have permissions)
   - Verify the tab title updates to reflect the new name

5. **Verify dashboard titles still work:**
   - Open a dashboard and verify its title appears in the tab
   - Navigate away from the dashboard
   - Verify the tab title resets to "Superset"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #7
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
