### PR TITLE
FEAT (Chart): Auto focuses visual selection search input

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -452,7 +452,7 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
     if (searchInputRef.current) {
       searchInputRef.current.focus();
     }
-  }, []);
+  }, []); 
 
   const chartMetadata: VizEntry[] = useMemo(() => {
     const result = Object.entries(mountedPluginMetadata)

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -447,6 +447,13 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
     ? mountedPluginMetadata[selectedViz]
     : null;
 
+  // Auto-focus the search input when the modal opens
+  useEffect(() => {
+    if (searchInputRef.current) {
+      searchInputRef.current.focus();
+    }
+  }, []);
+
   const chartMetadata: VizEntry[] = useMemo(() => {
     const result = Object.entries(mountedPluginMetadata)
       .map(([key, value]) => ({ key, value }))


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
[Issue](https://github.com/JuliettaRozin/superset/issues/1#issue-3467415935) stated that the search input in the "Change Visualization Type" (or View All Charts) modal must be manually clicked before the user types, adding unnecessary steps.
This solution works with the VizTypeGallery modal and automatically focuses the search input when the modal opens to be able to type immediately, using a useEffect that determines when the modal is opened.

### CODE REVIEW & BEFORE/AFTER DEMO
[Before/After Demo & Code Review](https://youtu.be/nv2sKso2Ibs)

### TESTING
The following manual tests were performed:
- A chart is selected in Explore view and the "View All Charts" button is clicked
- When the modal opens:
  - Cursor is automatically in the search input
  - You can type immediately without needing to click into the search input
- The modal is closed and reopened: provides same performance as before

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
- [x] Fixes #13 